### PR TITLE
Create hall effect homing sensor yaml

### DIFF
--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -30,7 +30,7 @@ axes:
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
-      limit_neg_pin: gpio.36:pu:low
+      limit_neg_pin: gpio.36:low
       hard_limits: true
       pulloff_mm: 2
       stepstick:
@@ -59,7 +59,7 @@ axes:
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
-      limit_neg_pin: gpio.35:pu:low
+      limit_neg_pin: gpio.35:low
       hard_limits: true
       pulloff_mm: 2
       stepstick:

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -94,10 +94,7 @@ control:
   estop_pin: NO_PIN
 
 macros:
-  # Move to center (half of max travel on each axis)
-  macro0: |
-    G90
-    G0 X162.5 Y5
+  macro0: G90
 
 coolant:
   flood_pin: NO_PIN

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -84,8 +84,8 @@ control:
   fault_pin: NO_PIN
   estop_pin: NO_PIN
 
-macros:
-  macro0: G90; G0 X162.5 Y5
+  macros:
+    macro0: G90 G0 X162.5 Y5
 
 coolant:
   flood_pin: NO_PIN

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -26,13 +26,13 @@ axes:
       mpos_mm: 0
       feed_mm_per_min: 200
       seek_mm_per_min: 500
-      settle_ms: 250
+      settle_ms: 500
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
       limit_neg_pin: gpio.36:low
       hard_limits: true
-      pulloff_mm: 2
+      pulloff_mm: 5
       stepstick:
         step_pin: i2so.1
         direction_pin: i2so.2
@@ -55,13 +55,13 @@ axes:
       mpos_mm: 0
       feed_mm_per_min: 120
       seek_mm_per_min: 200
-      settle_ms: 250
+      settle_ms: 500
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
       limit_neg_pin: gpio.35:low
       hard_limits: true
-      pulloff_mm: 2
+      pulloff_mm: 3
       stepstick:
         step_pin: i2so.5
         direction_pin: i2so.6:low
@@ -94,7 +94,10 @@ control:
   estop_pin: NO_PIN
 
 macros:
-  macro0: G90
+  # Move to center (half of max travel on each axis)
+  macro0: |
+    G90
+    G0 X162.5 Y5
 
 coolant:
   flood_pin: NO_PIN

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -20,9 +20,18 @@ axes:
     acceleration_mm_per_sec2: 500
     max_travel_mm: 325
     soft_limits: false
+    homing:
+      cycle: 1
+      positive_direction: false
+      mpos_mm: 0
+      feed_mm_per_min: 200
+      seek_mm_per_min: 500
+      settle_ms: 250
+      seek_scaler: 1.10
+      feed_scaler: 1.10
     motor0:
-      limit_neg_pin: gpio.36
-      hard_limits: false
+      limit_neg_pin: gpio.36:pu:low
+      hard_limits: true
       pulloff_mm: 2
       stepstick:
         step_pin: i2so.1
@@ -40,8 +49,18 @@ axes:
     acceleration_mm_per_sec2: 500
     max_travel_mm: 10
     soft_limits: false
+    homing:
+      cycle: 2
+      positive_direction: false
+      mpos_mm: 0
+      feed_mm_per_min: 120
+      seek_mm_per_min: 200
+      settle_ms: 250
+      seek_scaler: 1.10
+      feed_scaler: 1.10
     motor0:
-      limit_neg_pin: gpio.35
+      limit_neg_pin: gpio.35:pu:low
+      hard_limits: true
       pulloff_mm: 2
       stepstick:
         step_pin: i2so.5

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -24,8 +24,8 @@ axes:
       cycle: 1
       positive_direction: false
       mpos_mm: 0
-      feed_mm_per_min: 200
-      seek_mm_per_min: 500
+      feed_mm_per_min: 150
+      seek_mm_per_min: 300
       settle_ms: 500
       seek_scaler: 1.10
       feed_scaler: 1.10
@@ -35,7 +35,7 @@ axes:
       pulloff_mm: 5
       stepstick:
         step_pin: i2so.1
-        direction_pin: i2so.2
+        direction_pin: i2so.2:low
         disable_pin: NO_PIN
         ms1_pin: NO_PIN
         ms2_pin: NO_PIN

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -24,18 +24,18 @@ axes:
       cycle: 1
       positive_direction: false
       mpos_mm: 0
-      feed_mm_per_min: 150
-      seek_mm_per_min: 300
-      settle_ms: 500
+      feed_mm_per_min: 80
+      seek_mm_per_min: 150
+      settle_ms: 700
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
       limit_neg_pin: gpio.36:low
       hard_limits: true
-      pulloff_mm: 5
+      pulloff_mm: 8
       stepstick:
         step_pin: i2so.1
-        direction_pin: i2so.2:low
+        direction_pin: i2so.2
         disable_pin: NO_PIN
         ms1_pin: NO_PIN
         ms2_pin: NO_PIN
@@ -94,7 +94,7 @@ control:
   estop_pin: NO_PIN
 
 macros:
-  macro0: G90
+  macro0: G90; G0 X162.5 Y5
 
 coolant:
   flood_pin: NO_PIN

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -1,0 +1,133 @@
+board: MKS DLC32 v2.1
+name: DLC32 Hall Homing with TMC2209
+meta: Hall-effect endstops on X/Y/Z-, TMC2209 step/dir with UART addressing
+
+stepping:
+  engine: I2S_STATIC
+  idle_ms: 250
+  pulse_us: 4
+  dir_delay_us: 1
+  disable_delay_us: 0
+
+i2so:
+  bck_pin: gpio.22
+  ws_pin: gpio.17
+  data_pin: gpio.21
+
+axes:
+  # Shared enable for all stepper drivers via I2S
+  shared_stepper_disable_pin: I2SO.0
+
+  x:
+    steps_per_mm: 80.000
+    max_rate_mm_per_min: 6000.000
+    acceleration_mm_per_sec2: 800.000
+    max_travel_mm: 200.000
+    soft_limits: true
+    homing:
+      # Home Z first (cycle 1), then X&Y (cycle 2). X participates in cycle 2
+      cycle: 2
+      positive_direction: false
+      mpos_mm: 0.000
+      feed_mm_per_min: 300.000
+      seek_mm_per_min: 1500.000
+      settle_ms: 250
+      seek_scaler: 1.10
+      feed_scaler: 1.10
+    motor0:
+      # Hall-effect sensor at X- (active-low typical); adjust :low if your sensor is active-high
+      limit_neg_pin: gpio.36:low
+      hard_limits: true
+      pulloff_mm: 1.000
+      step_pin: I2SO.1
+      direction_pin: I2SO.2
+      # disable_pin is shared via shared_stepper_disable_pin
+      tmc_2209:
+        # If your DLC32 is wired for UART, these are typical settings.
+        # If you are using TMC2209 in standalone (no UART), remove this block
+        # and set microsteps/current via jumpers.
+        uart_num: 1
+        addr: 0
+        r_sense_ohms: 0.110
+        run_amps: 0.80
+        hold_amps: 0.40
+        microsteps: 16
+
+  y:
+    steps_per_mm: 80.000
+    max_rate_mm_per_min: 6000.000
+    acceleration_mm_per_sec2: 800.000
+    max_travel_mm: 200.000
+    soft_limits: true
+    homing:
+      # Y also homes in cycle 2 (with X)
+      cycle: 2
+      positive_direction: false
+      mpos_mm: 0.000
+      feed_mm_per_min: 300.000
+      seek_mm_per_min: 1500.000
+      settle_ms: 250
+      seek_scaler: 1.10
+      feed_scaler: 1.10
+    motor0:
+      # Hall-effect sensor at Y-
+      limit_neg_pin: gpio.35:low
+      hard_limits: true
+      pulloff_mm: 1.000
+      step_pin: I2SO.5
+      direction_pin: I2SO.6
+      tmc_2209:
+        uart_num: 1
+        addr: 1
+        r_sense_ohms: 0.110
+        run_amps: 0.80
+        hold_amps: 0.40
+        microsteps: 16
+
+  z:
+    steps_per_mm: 400.000
+    max_rate_mm_per_min: 1500.000
+    acceleration_mm_per_sec2: 100.000
+    max_travel_mm: 200.000
+    soft_limits: true
+    homing:
+      # Z homes first
+      cycle: 1
+      positive_direction: false
+      mpos_mm: 0.000
+      feed_mm_per_min: 120.000
+      seek_mm_per_min: 600.000
+      settle_ms: 250
+      seek_scaler: 1.10
+      feed_scaler: 1.10
+    motor0:
+      # Hall-effect sensor at Z-
+      limit_neg_pin: gpio.34:low
+      hard_limits: true
+      pulloff_mm: 1.000
+      step_pin: I2SO.9
+      direction_pin: I2SO.10
+      tmc_2209:
+        uart_num: 1
+        addr: 2
+        r_sense_ohms: 0.110
+        run_amps: 0.80
+        hold_amps: 0.40
+        microsteps: 16
+
+control:
+  # Optional: define control pins if wired on your DLC32; leave NO_PIN if unused
+  safety_door_pin: NO_PIN
+  reset_pin: NO_PIN
+  feed_hold_pin: NO_PIN
+  cycle_start_pin: NO_PIN
+
+start:
+  # Optional startup lines
+  startup_line0:
+  startup_line1:
+
+# Notes:
+# - Endstop pins use ESP32 input-only GPIOs 34/35/36; suffix :low makes them active-low (typical for 3-wire hall sensors).
+# - If an axis moves the wrong way during homing, flip its motor direction by adding :low to direction_pin or set positive_direction: true.
+# - If your board is not jumpered for TMC2209 UART, remove each tmc_2209 block and configure microsteps/current via jumpers on the drivers.

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -1,6 +1,6 @@
 board: MKS DLC32 v2.1
-name: DLC32 Hall Homing with TMC2209
-meta: Hall-effect endstops on X/Y/Z-, TMC2209 step/dir with UART addressing
+name: DLC32 Hall Homing (Hall endstops)
+meta: Hall-effect endstops on X/Y/Z-, Step/Dir drivers via I2S (no UART)
 
 stepping:
   engine: I2S_STATIC
@@ -35,12 +35,14 @@ axes:
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
+      driver: stepstick
       # Hall-effect sensor at X- (active-low typical); adjust :low if your sensor is active-high
       limit_neg_pin: gpio.36:low
       hard_limits: true
       pulloff_mm: 1.000
-      step_pin: I2SO.1
-      direction_pin: I2SO.2
+      stepstick:
+        step_pin: I2SO.1
+        direction_pin: I2SO.2
 
   y:
     steps_per_mm: 80.000
@@ -59,12 +61,14 @@ axes:
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
+      driver: stepstick
       # Hall-effect sensor at Y-
       limit_neg_pin: gpio.35:low
       hard_limits: true
       pulloff_mm: 1.000
-      step_pin: I2SO.5
-      direction_pin: I2SO.6
+      stepstick:
+        step_pin: I2SO.5
+        direction_pin: I2SO.6
 
   z:
     steps_per_mm: 400.000
@@ -83,12 +87,14 @@ axes:
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
+      driver: stepstick
       # Hall-effect sensor at Z-
       limit_neg_pin: gpio.34:low
       hard_limits: true
       pulloff_mm: 1.000
-      step_pin: I2SO.9
-      direction_pin: I2SO.10
+      stepstick:
+        step_pin: I2SO.9
+        direction_pin: I2SO.10
 
 control:
   # Optional: define control pins if wired on your DLC32; leave NO_PIN if unused

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -35,7 +35,6 @@ axes:
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
-      driver: stepstick
       # Hall-effect sensor at X- (active-low typical); adjust :low if your sensor is active-high
       limit_neg_pin: gpio.36:low
       hard_limits: true
@@ -61,7 +60,6 @@ axes:
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
-      driver: stepstick
       # Hall-effect sensor at Y-
       limit_neg_pin: gpio.35:low
       hard_limits: true
@@ -87,7 +85,6 @@ axes:
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
-      driver: stepstick
       # Hall-effect sensor at Z-
       limit_neg_pin: gpio.34:low
       hard_limits: true

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -41,17 +41,6 @@ axes:
       pulloff_mm: 1.000
       step_pin: I2SO.1
       direction_pin: I2SO.2
-      # disable_pin is shared via shared_stepper_disable_pin
-      tmc_2209:
-        # If your DLC32 is wired for UART, these are typical settings.
-        # If you are using TMC2209 in standalone (no UART), remove this block
-        # and set microsteps/current via jumpers.
-        uart_num: 1
-        addr: 0
-        r_sense_ohms: 0.110
-        run_amps: 0.80
-        hold_amps: 0.40
-        microsteps: 16
 
   y:
     steps_per_mm: 80.000
@@ -76,13 +65,6 @@ axes:
       pulloff_mm: 1.000
       step_pin: I2SO.5
       direction_pin: I2SO.6
-      tmc_2209:
-        uart_num: 1
-        addr: 1
-        r_sense_ohms: 0.110
-        run_amps: 0.80
-        hold_amps: 0.40
-        microsteps: 16
 
   z:
     steps_per_mm: 400.000
@@ -107,13 +89,6 @@ axes:
       pulloff_mm: 1.000
       step_pin: I2SO.9
       direction_pin: I2SO.10
-      tmc_2209:
-        uart_num: 1
-        addr: 2
-        r_sense_ohms: 0.110
-        run_amps: 0.80
-        hold_amps: 0.40
-        microsteps: 16
 
 control:
   # Optional: define control pins if wired on your DLC32; leave NO_PIN if unused
@@ -122,10 +97,6 @@ control:
   feed_hold_pin: NO_PIN
   cycle_start_pin: NO_PIN
 
-start:
-  # Optional startup lines
-  startup_line0:
-  startup_line1:
 
 # Notes:
 # - Endstop pins use ESP32 input-only GPIOs 34/35/36; suffix :low makes them active-low (typical for 3-wire hall sensors).

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -1,107 +1,105 @@
-board: MKS DLC32 v2.1
-name: DLC32 Hall Homing (Hall endstops)
-meta: Hall-effect endstops on X/Y/Z-, Step/Dir drivers via I2S (no UART)
+board: MKS-DLC32 V2.1
+name: Dune Weaver Pro
+meta: By Tuan Nguyen (2025-02-16)
+
+kinematics: {}
 
 stepping:
   engine: I2S_STATIC
-  idle_ms: 250
+  idle_ms: 0
   pulse_us: 4
   dir_delay_us: 1
   disable_delay_us: 0
 
-i2so:
-  bck_pin: gpio.22
-  ws_pin: gpio.17
-  data_pin: gpio.21
-
 axes:
-  # Shared enable for all stepper drivers via I2S
-  shared_stepper_disable_pin: I2SO.0
+  shared_stepper_disable_pin: i2so.0
 
   x:
-    steps_per_mm: 80.000
-    max_rate_mm_per_min: 6000.000
-    acceleration_mm_per_sec2: 800.000
-    max_travel_mm: 200.000
-    soft_limits: true
-    homing:
-      # Home Z first (cycle 1), then X&Y (cycle 2). X participates in cycle 2
-      cycle: 2
-      positive_direction: false
-      mpos_mm: 0.000
-      feed_mm_per_min: 300.000
-      seek_mm_per_min: 1500.000
-      settle_ms: 250
-      seek_scaler: 1.10
-      feed_scaler: 1.10
+    steps_per_mm: 320
+    max_rate_mm_per_min: 2000
+    acceleration_mm_per_sec2: 500
+    max_travel_mm: 325
+    soft_limits: false
     motor0:
-      # Hall-effect sensor at X- (active-low typical); adjust :low if your sensor is active-high
-      limit_neg_pin: gpio.36:low
-      hard_limits: true
-      pulloff_mm: 1.000
+      limit_neg_pin: gpio.36
+      hard_limits: false
+      pulloff_mm: 2
       stepstick:
-        step_pin: I2SO.1
-        direction_pin: I2SO.2
+        step_pin: i2so.1
+        direction_pin: i2so.2
+        disable_pin: NO_PIN
+        ms1_pin: NO_PIN
+        ms2_pin: NO_PIN
+        ms3_pin: NO_PIN
+      limit_pos_pin: NO_PIN
+      limit_all_pin: NO_PIN
 
   y:
-    steps_per_mm: 80.000
-    max_rate_mm_per_min: 6000.000
-    acceleration_mm_per_sec2: 800.000
-    max_travel_mm: 200.000
-    soft_limits: true
-    homing:
-      # Y also homes in cycle 2 (with X)
-      cycle: 2
-      positive_direction: false
-      mpos_mm: 0.000
-      feed_mm_per_min: 300.000
-      seek_mm_per_min: 1500.000
-      settle_ms: 250
-      seek_scaler: 1.10
-      feed_scaler: 1.10
+    steps_per_mm: 533
+    max_rate_mm_per_min: 2000
+    acceleration_mm_per_sec2: 500
+    max_travel_mm: 10
+    soft_limits: false
     motor0:
-      # Hall-effect sensor at Y-
-      limit_neg_pin: gpio.35:low
-      hard_limits: true
-      pulloff_mm: 1.000
+      limit_neg_pin: gpio.35
+      pulloff_mm: 2
       stepstick:
-        step_pin: I2SO.5
-        direction_pin: I2SO.6
+        step_pin: i2so.5
+        direction_pin: i2so.6:low
+        disable_pin: NO_PIN
+        ms1_pin: NO_PIN
+        ms2_pin: NO_PIN
+        ms3_pin: NO_PIN
+      limit_pos_pin: NO_PIN
+      limit_all_pin: NO_PIN
 
-  z:
-    steps_per_mm: 400.000
-    max_rate_mm_per_min: 1500.000
-    acceleration_mm_per_sec2: 100.000
-    max_travel_mm: 200.000
-    soft_limits: true
-    homing:
-      # Z homes first
-      cycle: 1
-      positive_direction: false
-      mpos_mm: 0.000
-      feed_mm_per_min: 120.000
-      seek_mm_per_min: 600.000
-      settle_ms: 250
-      seek_scaler: 1.10
-      feed_scaler: 1.10
-    motor0:
-      # Hall-effect sensor at Z-
-      limit_neg_pin: gpio.34:low
-      hard_limits: true
-      pulloff_mm: 1.000
-      stepstick:
-        step_pin: I2SO.9
-        direction_pin: I2SO.10
+i2so:
+  bck_pin: gpio.16
+  data_pin: gpio.21
+  ws_pin: gpio.17
+
+sdcard:
+  cs_pin: gpio.15
+  card_detect_pin: NO_PIN
 
 control:
-  # Optional: define control pins if wired on your DLC32; leave NO_PIN if unused
   safety_door_pin: NO_PIN
   reset_pin: NO_PIN
   feed_hold_pin: NO_PIN
   cycle_start_pin: NO_PIN
+  macro0_pin: gpio.33:pu:low
+  macro1_pin: NO_PIN
+  macro2_pin: NO_PIN
+  macro3_pin: NO_PIN
+  fault_pin: NO_PIN
+  estop_pin: NO_PIN
 
+macros:
+  macro0: G90
 
-# Notes:
-# - Endstop pins use ESP32 input-only GPIOs 34/35/36; suffix :low makes them active-low (typical for 3-wire hall sensors).
-# - If an axis moves the wrong way during homing, flip its motor direction by adding :low to direction_pin or set positive_direction: true.
-# - If your board is not jumpered for TMC2209 UART, remove each tmc_2209 block and configure microsteps/current via jumpers on the drivers.
+coolant:
+  flood_pin: NO_PIN
+  mist_pin: NO_PIN
+  delay_ms: 0
+
+user_outputs:
+  analog0_pin: NO_PIN
+  analog1_pin: NO_PIN
+  analog2_pin: NO_PIN
+  analog3_pin: NO_PIN
+  analog0_hz: 5000
+  analog1_hz: 5000
+  analog2_hz: 5000
+  analog3_hz: 5000
+  digital0_pin: NO_PIN
+  digital1_pin: NO_PIN
+  digital2_pin: NO_PIN
+  digital3_pin: NO_PIN
+
+start:
+  must_home: false
+
+spi:
+  miso_pin: gpio.12
+  mosi_pin: gpio.13
+  sck_pin: gpio.14

--- a/mks_dlc32_hall_homing.yaml
+++ b/mks_dlc32_hall_homing.yaml
@@ -49,15 +49,6 @@ axes:
     acceleration_mm_per_sec2: 500
     max_travel_mm: 10
     soft_limits: false
-    homing:
-      cycle: 2
-      positive_direction: false
-      mpos_mm: 0
-      feed_mm_per_min: 120
-      seek_mm_per_min: 200
-      settle_ms: 500
-      seek_scaler: 1.10
-      feed_scaler: 1.10
     motor0:
       limit_neg_pin: gpio.35:low
       hard_limits: true
@@ -86,7 +77,7 @@ control:
   reset_pin: NO_PIN
   feed_hold_pin: NO_PIN
   cycle_start_pin: NO_PIN
-  macro0_pin: gpio.33:pu:low
+  macro0_pin: NO_PIN
   macro1_pin: NO_PIN
   macro2_pin: NO_PIN
   macro3_pin: NO_PIN

--- a/mks_dlc32_sensorless.yaml
+++ b/mks_dlc32_sensorless.yaml
@@ -57,6 +57,7 @@ axes:
         r_sense_ohms: 0.110
         run_amps: 0.80
         hold_amps: 0.40
+        homing_amps: 0.60
         microsteps: 16
         # Sensorless settings
         stallguard: 8
@@ -96,6 +97,7 @@ axes:
         r_sense_ohms: 0.110
         run_amps: 0.80
         hold_amps: 0.40
+        homing_amps: 0.60
         microsteps: 16
         stallguard: 8
         stallguard_debug: false

--- a/mks_dlc32_sensorless.yaml
+++ b/mks_dlc32_sensorless.yaml
@@ -1,0 +1,153 @@
+board: MKS-DLC32 V2.1
+name: Dune Weaver Pro (Sensorless)
+meta: Sensorless homing on X/Y with TMC2209 (UART); based on pins you provided
+
+kinematics: {}
+
+stepping:
+  engine: I2S_STATIC
+  idle_ms: 0
+  pulse_us: 4
+  dir_delay_us: 1
+  disable_delay_us: 0
+
+i2so:
+  bck_pin: gpio.16
+  data_pin: gpio.21
+  ws_pin: gpio.17
+
+# NOTE: You must wire the TMC2209 UART bus to these pins on the DLC32
+# Adjust if your wiring uses different GPIOs
+uart1:
+  txd_pin: gpio.4
+  rxd_pin: gpio.0
+  rts_pin: NO_PIN
+  cts_pin: NO_PIN
+  baud: 115200
+  mode: 8N1
+
+axes:
+  shared_stepper_disable_pin: i2so.0
+
+  x:
+    steps_per_mm: 320
+    max_rate_mm_per_min: 2000
+    acceleration_mm_per_sec2: 500
+    max_travel_mm: 325
+    soft_limits: false
+    homing:
+      cycle: 1
+      positive_direction: false
+      mpos_mm: 0
+      feed_mm_per_min: 80
+      seek_mm_per_min: 150
+      settle_ms: 600
+      seek_scaler: 1.10
+      feed_scaler: 1.10
+    motor0:
+      # Sensorless: no physical limits
+      limit_neg_pin: NO_PIN
+      limit_pos_pin: NO_PIN
+      limit_all_pin: NO_PIN
+      hard_limits: false
+      pulloff_mm: 6
+      tmc_2209:
+        uart_num: 1
+        addr: 0
+        r_sense_ohms: 0.110
+        run_amps: 0.80
+        hold_amps: 0.40
+        microsteps: 16
+        # Sensorless settings
+        stallguard: 8
+        stallguard_debug: false
+        run_mode: SpreadCycle
+        homing_mode: SpreadCycle
+        use_enable: false
+        # Step/dir via I2S
+        step_pin: i2so.1
+        direction_pin: i2so.2
+        disable_pin: NO_PIN
+
+  y:
+    steps_per_mm: 533
+    max_rate_mm_per_min: 2000
+    acceleration_mm_per_sec2: 500
+    max_travel_mm: 10
+    soft_limits: false
+    homing:
+      cycle: 2
+      positive_direction: false
+      mpos_mm: 0
+      feed_mm_per_min: 80
+      seek_mm_per_min: 150
+      settle_ms: 600
+      seek_scaler: 1.10
+      feed_scaler: 1.10
+    motor0:
+      limit_neg_pin: NO_PIN
+      limit_pos_pin: NO_PIN
+      limit_all_pin: NO_PIN
+      hard_limits: false
+      pulloff_mm: 4
+      tmc_2209:
+        uart_num: 1
+        addr: 1
+        r_sense_ohms: 0.110
+        run_amps: 0.80
+        hold_amps: 0.40
+        microsteps: 16
+        stallguard: 8
+        stallguard_debug: false
+        run_mode: SpreadCycle
+        homing_mode: SpreadCycle
+        use_enable: false
+        step_pin: i2so.5
+        direction_pin: i2so.6:low
+        disable_pin: NO_PIN
+
+sdcard:
+  cs_pin: gpio.15
+  card_detect_pin: NO_PIN
+
+control:
+  safety_door_pin: NO_PIN
+  reset_pin: NO_PIN
+  feed_hold_pin: NO_PIN
+  cycle_start_pin: NO_PIN
+  macro0_pin: NO_PIN
+  macro1_pin: NO_PIN
+  macro2_pin: NO_PIN
+  macro3_pin: NO_PIN
+  fault_pin: NO_PIN
+  estop_pin: NO_PIN
+
+macros:
+  macro0: G90 G0 X162.5 Y5
+
+coolant:
+  flood_pin: NO_PIN
+  mist_pin: NO_PIN
+  delay_ms: 0
+
+user_outputs:
+  analog0_pin: NO_PIN
+  analog1_pin: NO_PIN
+  analog2_pin: NO_PIN
+  analog3_pin: NO_PIN
+  analog0_hz: 5000
+  analog1_hz: 5000
+  analog2_hz: 5000
+  analog3_hz: 5000
+  digital0_pin: NO_PIN
+  digital1_pin: NO_PIN
+  digital2_pin: NO_PIN
+  digital3_pin: NO_PIN
+
+start:
+  must_home: false
+
+spi:
+  miso_pin: gpio.12
+  mosi_pin: gpio.13
+  sck_pin: gpio.14

--- a/mks_dlc32_sisyphus_hall.yaml
+++ b/mks_dlc32_sisyphus_hall.yaml
@@ -70,8 +70,8 @@ axes:
     motor0:
       # Hall sensor for Y on GPIO35 (active-low typical)
       limit_neg_pin: gpio.35:low
-      hard_limits: true
-      pulloff_mm: 4
+      hard_limits: false
+      pulloff_mm: 1
       stepstick:
         step_pin: i2so.5
         direction_pin: i2so.6:low

--- a/mks_dlc32_sisyphus_hall.yaml
+++ b/mks_dlc32_sisyphus_hall.yaml
@@ -56,7 +56,7 @@ axes:
     steps_per_mm: 533
     max_rate_mm_per_min: 2000
     acceleration_mm_per_sec2: 500
-    max_travel_mm: 10
+    max_travel_mm: 200
     soft_limits: false
     homing:
       cycle: 2

--- a/mks_dlc32_sisyphus_hall.yaml
+++ b/mks_dlc32_sisyphus_hall.yaml
@@ -1,0 +1,130 @@
+board: MKS-DLC32 V2.1
+name: Dune Weaver Pro (Hall Homing - Sisyphus style)
+meta: X (theta) then Y (rho) homing with hall sensors, two-pass, larger pulloff, center macro
+
+kinematics: {}
+
+stepping:
+  engine: I2S_STATIC
+  idle_ms: 0
+  pulse_us: 4
+  dir_delay_us: 1
+  disable_delay_us: 0
+
+i2so:
+  bck_pin: gpio.16
+  data_pin: gpio.21
+  ws_pin: gpio.17
+
+axes:
+  shared_stepper_disable_pin: i2so.0
+
+  # X = theta (rotation)
+  x:
+    steps_per_mm: 320
+    max_rate_mm_per_min: 2000
+    acceleration_mm_per_sec2: 500
+    max_travel_mm: 325
+    soft_limits: false
+    homing:
+      cycle: 1
+      positive_direction: false
+      mpos_mm: 0
+      # Two-pass homing: slow to ensure clean detect with hall
+      seek_mm_per_min: 150
+      feed_mm_per_min: 80
+      settle_ms: 700
+      seek_scaler: 1.10
+      feed_scaler: 1.10
+    motor0:
+      # Hall sensor for X on GPIO36 (active-low typical)
+      limit_neg_pin: gpio.36:low
+      hard_limits: true
+      pulloff_mm: 8
+      stepstick:
+        step_pin: i2so.1
+        direction_pin: i2so.2
+        disable_pin: NO_PIN
+        ms1_pin: NO_PIN
+        ms2_pin: NO_PIN
+        ms3_pin: NO_PIN
+      limit_pos_pin: NO_PIN
+      limit_all_pin: NO_PIN
+
+  # Y = rho (radial)
+  y:
+    steps_per_mm: 533
+    max_rate_mm_per_min: 2000
+    acceleration_mm_per_sec2: 500
+    max_travel_mm: 10
+    soft_limits: false
+    homing:
+      cycle: 2
+      positive_direction: false
+      mpos_mm: 0
+      seek_mm_per_min: 120
+      feed_mm_per_min: 60
+      settle_ms: 700
+      seek_scaler: 1.10
+      feed_scaler: 1.10
+    motor0:
+      # Hall sensor for Y on GPIO35 (active-low typical)
+      limit_neg_pin: gpio.35:low
+      hard_limits: true
+      pulloff_mm: 4
+      stepstick:
+        step_pin: i2so.5
+        direction_pin: i2so.6:low
+        disable_pin: NO_PIN
+        ms1_pin: NO_PIN
+        ms2_pin: NO_PIN
+        ms3_pin: NO_PIN
+      limit_pos_pin: NO_PIN
+      limit_all_pin: NO_PIN
+
+sdcard:
+  cs_pin: gpio.15
+  card_detect_pin: NO_PIN
+
+control:
+  safety_door_pin: NO_PIN
+  reset_pin: NO_PIN
+  feed_hold_pin: NO_PIN
+  cycle_start_pin: NO_PIN
+  macro0_pin: NO_PIN
+  macro1_pin: NO_PIN
+  macro2_pin: NO_PIN
+  macro3_pin: NO_PIN
+  fault_pin: NO_PIN
+  estop_pin: NO_PIN
+
+macros:
+  # Move to center after homing (half of max travel on Y, and mid-angle)
+  macro0: G90 G0 X162.5 Y5
+
+coolant:
+  flood_pin: NO_PIN
+  mist_pin: NO_PIN
+  delay_ms: 0
+
+user_outputs:
+  analog0_pin: NO_PIN
+  analog1_pin: NO_PIN
+  analog2_pin: NO_PIN
+  analog3_pin: NO_PIN
+  analog0_hz: 5000
+  analog1_hz: 5000
+  analog2_hz: 5000
+  analog3_hz: 5000
+  digital0_pin: NO_PIN
+  digital1_pin: NO_PIN
+  digital2_pin: NO_PIN
+  digital3_pin: NO_PIN
+
+start:
+  must_home: false
+
+spi:
+  miso_pin: gpio.12
+  mosi_pin: gpio.13
+  sck_pin: gpio.14

--- a/mks_dlc32_sisyphus_hall.yaml
+++ b/mks_dlc32_sisyphus_hall.yaml
@@ -39,7 +39,7 @@ axes:
     motor0:
       # Hall sensor for X on GPIO36 (active-low typical)
       limit_neg_pin: gpio.36:low
-      hard_limits: true
+      hard_limits: false
       pulloff_mm: 8
       stepstick:
         step_pin: i2so.1

--- a/mks_dlc32_sisyphus_hall.yaml
+++ b/mks_dlc32_sisyphus_hall.yaml
@@ -62,14 +62,14 @@ axes:
       cycle: 2
       positive_direction: false
       mpos_mm: 0
-      seek_mm_per_min: 120
-      feed_mm_per_min: 60
+      seek_mm_per_min: 100
+      feed_mm_per_min: 50
       settle_ms: 700
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
-      # Hall sensor for Y on GPIO35 (active-low typical)
-      limit_neg_pin: gpio.35:low
+      # Hall sensor for Y on GPIO34 (active-low typical)
+      limit_neg_pin: gpio.34:low
       hard_limits: true
       pulloff_mm: 4
       stepstick:

--- a/mks_dlc32_sisyphus_hall.yaml
+++ b/mks_dlc32_sisyphus_hall.yaml
@@ -68,8 +68,8 @@ axes:
       seek_scaler: 1.10
       feed_scaler: 1.10
     motor0:
-      # Hall sensor for Y on GPIO34 (active-low typical)
-      limit_neg_pin: gpio.34:low
+      # Hall sensor for Y on GPIO35 (active-low typical)
+      limit_neg_pin: gpio.35:low
       hard_limits: true
       pulloff_mm: 4
       stepstick:


### PR DESCRIPTION
Add FluidNC YAML for MKS DLC32 v2.1 to configure hall-effect homing with TMC2209 drivers.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f1c983f-6fb3-476e-9fb4-4eed5b22e49f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f1c983f-6fb3-476e-9fb4-4eed5b22e49f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

